### PR TITLE
Allow relative URLs

### DIFF
--- a/src/Model/Resource/Link/Link.php
+++ b/src/Model/Resource/Link/Link.php
@@ -26,7 +26,13 @@ class Link implements LinkInterface
         if ($name === '') {
             throw new \InvalidArgumentException('Invalid link name');
         }
-        if (filter_var($href, FILTER_VALIDATE_URL) === false) {
+
+        $validateUrl = $href;
+        if (substr($validateUrl, 0, 1) === '/')  {
+               $validateUrl = 'http://www.example.com' . $href;
+        }
+
+        if (filter_var($validateUrl, FILTER_VALIDATE_URL) === false) {
             throw new \InvalidArgumentException('Invalid link target');
         }
 

--- a/tests/Model/Resource/Link/LinkTest.php
+++ b/tests/Model/Resource/Link/LinkTest.php
@@ -47,4 +47,15 @@ class LinkTest extends TestCase
     {
         new Link('about', 'jsonapi.org');
     }
+
+    public function testRelativeLink()
+    {
+        $link = new Link('about', '/resource');
+        $link->metaInformation()->set('test', 'test');
+
+        self::assertEquals('about', $link->name());
+        self::assertEquals('/resource', $link->href());
+        self::assertArrayHasKey('test', $link->metaInformation()->all());
+    }
+
 }


### PR DESCRIPTION
The JSON API Spec does not explicitly define the structure of URL in a Link (either when the link value is a URL string or when the link value is an object with an `href` string property).

The schema defines a link as `uri-reference` (https://github.com/json-api/json-api/blob/gh-pages/schema#L180) which may be relative or absolute as opposed to `uri` which would be absolute only*.

The move from `uri` to `uri-reference` happened in this (merged) PR: https://github.com/json-api/json-api/pull/1169/files

This PR checks if the provided href is prefixed by `/` (indicating a relative path) and if so, prepends the valid "http://www.example.com" string to the path, which allows us to still use PHP's `filter_var` function with `FILTER_VALIDATE_URL` definition.  Both absolute and relative URL's now pass in the test(s) and the relative URL is still validated by PHP internals.

* https://www.ietf.org/rfc/rfc3986.txt

