### PR TITLE
Add countable interface to collections

### DIFF
--- a/src/Model/Common/CollectionInterface.php
+++ b/src/Model/Common/CollectionInterface.php
@@ -6,18 +6,18 @@ namespace Enm\JsonApi\Model\Common;
 /**
  * @author Philipp Marien <marien@eosnewmedia.de>
  */
-interface CollectionInterface
+interface CollectionInterface extends \Countable
 {
     /**
      * @return array
      */
     public function all(): array;
-    
+
     /**
      * @return bool
      */
     public function isEmpty(): bool;
-    
+
     /**
      * @return int
      */

--- a/tests/Model/Common/KeyValueCollectionTest.php
+++ b/tests/Model/Common/KeyValueCollectionTest.php
@@ -20,7 +20,7 @@ class KeyValueCollectionTest extends TestCase
     public function testCount(): void
     {
         $collection = new KeyValueCollection(['test' => 'test']);
-        self::assertEquals(1, $collection->count());
+        self::assertCount(1, $collection);
     }
 
     public function testIsEmpty(): void

--- a/tests/Model/Resource/SingleResourceCollectionTest.php
+++ b/tests/Model/Resource/SingleResourceCollectionTest.php
@@ -17,13 +17,13 @@ class SingleResourceCollectionTest extends TestCase
     {
         $collection = new SingleResourceCollection();
 
-        self::assertEquals(0, $collection->count());
+        self::assertCount(0, $collection);
 
         /** @var ResourceInterface $resource */
         $resource = $this->createMock(ResourceInterface::class);
         $collection->set($resource);
 
-        self::assertEquals(1, $collection->count());
+        self::assertCount(1, $collection);
     }
 
     /**


### PR DESCRIPTION
Hi,
this adds SPL `\Countable` interface to all collections, allowing calls like `count($resourceCollection)`.