### PR TITLE
Declare public constant for json api Content-Type

### DIFF
--- a/src/Model/JsonApi.php
+++ b/src/Model/JsonApi.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Enm\JsonApi\Model;
+
+class JsonApi
+{
+    public const CONTENT_TYPE = 'application/vnd.api+json';
+
+    private function __construct()
+    {
+        // private constructor to disallow class instantiation
+    }
+}

--- a/src/Model/Request/Request.php
+++ b/src/Model/Request/Request.php
@@ -8,6 +8,7 @@ use Enm\JsonApi\Exception\UnsupportedMediaTypeException;
 use Enm\JsonApi\Model\Common\KeyValueCollection;
 use Enm\JsonApi\Model\Common\KeyValueCollectionInterface;
 use Enm\JsonApi\Model\Document\DocumentInterface;
+use Enm\JsonApi\Model\JsonApi;
 use Enm\JsonApi\Model\Resource\ResourceInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -131,7 +132,7 @@ class Request implements RequestInterface
         $this->parseUriQuery($this->uri->getQuery());
 
         $this->headers = new KeyValueCollection();
-        $this->headers->set('Content-Type', 'application/vnd.api+json');
+        $this->headers->set('Content-Type', JsonApi::CONTENT_TYPE);
     }
 
     /**
@@ -300,7 +301,7 @@ class Request implements RequestInterface
             $apiRequest->headers()->set($header, \count($values) !== 1 ? $values : $values[0]);
         }
 
-        if ($apiRequest->headers()->getRequired('content-type') !== 'application/vnd.api+json') {
+        if ($apiRequest->headers()->getRequired('content-type') !== JsonApi::CONTENT_TYPE) {
             throw new UnsupportedMediaTypeException($apiRequest->headers()->getRequired('content-type'));
         }
 

--- a/src/Model/Response/AbstractResponse.php
+++ b/src/Model/Response/AbstractResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Enm\JsonApi\Model\Response;
 
 use Enm\JsonApi\Model\Common\KeyValueCollectionInterface;
+use Enm\JsonApi\Model\JsonApi;
 
 /**
  * @author Philipp Marien <marien@eosnewmedia.de>
@@ -28,7 +29,7 @@ abstract class AbstractResponse implements ResponseInterface
     {
         $this->status = $status;
         $this->headers = $headers;
-        $this->headers->set('Content-Type', 'application/vnd.api+json');
+        $this->headers->set('Content-Type', JsonApi::CONTENT_TYPE);
     }
 
     /**


### PR DESCRIPTION
Hi,
I suggest adding constant with JSON API Content-Type. It is used multiple times here in JSON-API-Common, as well as in JSON-API-Server and JSON-API-Server-Bundle. The constant would also be useful in other cases (such as functional testing, where you need to build request with proper content type) - so you don't need to declare it yourselves.

What do you think?