### PR TITLE
Array properties should be defined as array

### DIFF
--- a/src/Model/Request/Request.php
+++ b/src/Model/Request/Request.php
@@ -70,32 +70,32 @@ class Request implements RequestInterface
     /**
      * @var array
      */
-    private $fields;
+    private $fields = [];
 
     /**
      * @var array
      */
-    private $includes;
+    private $includes = [];
 
     /**
      * @var array
      */
-    private $currentLevelIncludes;
+    private $currentLevelIncludes = [];
 
     /**
      * @var array
      */
-    private $filter;
+    private $filter = [];
 
     /**
      * @var array
      */
-    private $order;
+    private $order = [];
 
     /**
      * @var array
      */
-    private $pagination;
+    private $pagination = [];
 
     /**
      * @var DocumentInterface|null


### PR DESCRIPTION
Without this fix it triggers errors like. `in_array() expects parameter 2 to be array, null given`