### PR TITLE
Filter the query params since this breaks servers.

### DIFF
--- a/src/Model/Request/Request.php
+++ b/src/Model/Request/Request.php
@@ -280,6 +280,9 @@ class Request implements RequestInterface
             'fields' => $fields
         ];
 
+        // Remove empty query params.
+        $query = array_filter($query);
+
         $this->uri = $this->uri()->withQuery(http_build_query($query));
     }
 


### PR DESCRIPTION
Drupal's JsonAPI implementation expects a valid `sort` parameter, when the library sends just `sort=`.

As such, we really shouldn't be sending any of these filter params as empty strings.