### PR TITLE
Use `page` query param instead of `pagination`.

### DIFF
--- a/src/Model/Request/Request.php
+++ b/src/Model/Request/Request.php
@@ -274,7 +274,7 @@ class Request implements RequestInterface
 
         $query = [
             'sort' => implode(',', $sort),
-            'pagination' => $this->pagination,
+            'page' => $this->pagination,
             'filter' => $this->filter,
             'include' => implode(',', $this->includes),
             'fields' => $fields


### PR DESCRIPTION
The use of `page` is defined by the jsonapi spec.

See https://jsonapi.org/format/#fetching-pagination.

Resolved #15.