### PR TITLE
JsonApiException should support multiple errors at once

### DIFF
--- a/docs/06-errors.md
+++ b/docs/06-errors.md
@@ -1,28 +1,20 @@
 [back to README](../README.md)
 # Exceptions and Errors
-Exceptions should turned into instances of `Enm\JsonApi\Model\Error\ErrorInterface` if you want to serialize errors for output.
+The `JsonApiException` automatically creates an error collection by default and converts the current Exception context given in the constructor to the first error (`Enm\JsonApi\Model\Error\ErrorInterface`).
 
-The simplest way is to use the default implementation `Enm\JsonApi\Model\Error\Error`, which offers a static method to create an 
-error object from an exception.
-
-```php
-Enm\JsonApi\Model\Error\Error::createFrom(new \Exception('Test'));
-```
+The instantiated collection can be retrieved and appended by calling the `errors()` method which returns an instance of `Enm\JsonApi\Model\Error\ErrorCollectionInterface`.
 
 These exceptions are available to be handled including the correct http status code:
 
 |  Exception                                            | Description                           |
 |-------------------------------------------------------|---------------------------------------|
-| `Enm\JsonApi\Exception\Exception`                     | For general server errors             |
-| `Enm\JsonApi\Exception\InvalidRequestException`       | For client (request) errors           |
+| `Enm\JsonApi\Exception\JsonApiException`              | For general server errors             |
+| `Enm\JsonApi\Exception\BadRequestException`           | For client (request) errors           |
 | `Enm\JsonApi\Exception\ResourceNotFoundException`     | For 404 errors on a concrete resource |
 | `Enm\JsonApi\Exception\UnsupportedMediaTypeException` | For invalid content type header       |
 | `Enm\JsonApi\Exception\UnsupportedTypeException`      | For 404 errors on a resource list     |
 | `Enm\JsonApi\Exception\NotAllowedException`           | For 403 errors                        |
 | `Enm\JsonApi\Exception\HttpException`                 | For custom http status codes          |
-
-# Document errors
-Document errors are grouped within their document by an object of type `Enm\JsonApi\Model\Error\ErrorCollectionInterface`.
 
 *****
 

--- a/src/Exception/JsonApiException.php
+++ b/src/Exception/JsonApiException.php
@@ -4,26 +4,38 @@ declare(strict_types=1);
 namespace Enm\JsonApi\Exception;
 
 use Enm\JsonApi\Model\Error\Error;
-use Enm\JsonApi\Model\Error\ErrorInterface;
+use Enm\JsonApi\Model\Error\ErrorCollection;
+use Enm\JsonApi\Model\Error\ErrorCollectionInterface;
+use Throwable;
 
 /**
  * @author Philipp Marien <marien@eosnewmedia.de>
  */
 class JsonApiException extends \Exception
 {
-    /**
-     * @return int
-     */
+    /** @var ErrorCollectionInterface */
+    protected $errorCollection;
+
+    public function __construct(
+        $message = "",
+        $code = 0,
+        Throwable $previous = null,
+        ErrorCollectionInterface $errors = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->errorCollection = $errors ?? new ErrorCollection();
+        $this->errorCollection->add(
+            Error::createFrom($this)
+        );
+    }
+
     public function getHttpStatus(): int
     {
         return 500;
     }
 
-    /**
-     * @return ErrorInterface
-     */
-    public function createError(): ErrorInterface
+    public function errors(): ErrorCollectionInterface
     {
-        return Error::createFrom($this);
+        return $this->errorCollection;
     }
 }

--- a/src/Model/Error/ErrorCollection.php
+++ b/src/Model/Error/ErrorCollection.php
@@ -21,4 +21,9 @@ class ErrorCollection extends AbstractCollection implements ErrorCollectionInter
 
         return $this;
     }
+
+    public function first(): ?ErrorInterface
+    {
+        return reset($this->collection) ?: null;
+    }
 }

--- a/src/Model/Error/ErrorCollectionInterface.php
+++ b/src/Model/Error/ErrorCollectionInterface.php
@@ -14,11 +14,16 @@ interface ErrorCollectionInterface extends CollectionInterface
      * @return ErrorInterface[]
      */
     public function all(): array;
-    
+
     /**
      * @param ErrorInterface $error
      *
      * @return ErrorCollectionInterface
      */
     public function add(ErrorInterface $error): ErrorCollectionInterface;
+
+    /**
+     * @return ErrorInterface|null
+     */
+    public function first(): ?ErrorInterface;
 }

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -10,6 +10,7 @@ use Enm\JsonApi\Exception\NotAllowedException;
 use Enm\JsonApi\Exception\ResourceNotFoundException;
 use Enm\JsonApi\Exception\UnsupportedMediaTypeException;
 use Enm\JsonApi\Exception\UnsupportedTypeException;
+use Enm\JsonApi\Model\Error\ErrorInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,7 +25,8 @@ class ExceptionTest extends TestCase
         self::assertInstanceOf(JsonApiException::class, $exception);
         self::assertEquals(400, $exception->getHttpStatus());
         self::assertEquals('Invalid Request!', $exception->getMessage());
-        self::assertEquals('Invalid Request!', $exception->createError()->title());
+        self::assertInstanceOf(ErrorInterface::class, $exception->errors()->first());
+        self::assertEquals('Invalid Request!', $exception->errors()->first()->title());
     }
 
     public function testResourceNotFoundException(): void
@@ -37,9 +39,10 @@ class ExceptionTest extends TestCase
             'Resource "id" of type "test" not found!',
             $exception->getMessage()
         );
+        self::assertInstanceOf(ErrorInterface::class, $exception->errors()->first());
         self::assertEquals(
             'Resource "id" of type "test" not found!',
-            $exception->createError()->title()
+            $exception->errors()->first()->title()
         );
     }
 
@@ -50,7 +53,8 @@ class ExceptionTest extends TestCase
         self::assertInstanceOf(JsonApiException::class, $exception);
         self::assertEquals(415, $exception->getHttpStatus());
         self::assertEquals('Invalid content type: text/html', $exception->getMessage());
-        self::assertEquals('Invalid content type: text/html', $exception->createError()->title());
+        self::assertInstanceOf(ErrorInterface::class, $exception->errors()->first());
+        self::assertEquals('Invalid content type: text/html', $exception->errors()->first()->title());
     }
 
     public function testException(): void
@@ -59,7 +63,8 @@ class ExceptionTest extends TestCase
         self::assertInstanceOf(\Exception::class, $exception);
         self::assertEquals(500, $exception->getHttpStatus());
 
-        $error = $exception->createError();
+        $error = $exception->errors()->first();
+        self::assertInstanceOf(ErrorInterface::class, $error);
         self::assertEquals(500, $error->status());
         self::assertEquals('Test', $error->title());
     }
@@ -70,7 +75,8 @@ class ExceptionTest extends TestCase
         self::assertInstanceOf(\Exception::class, $exception);
         self::assertEquals(404, $exception->getHttpStatus());
 
-        $error = $exception->createError();
+        $error = $exception->errors()->first();
+        self::assertInstanceOf(ErrorInterface::class, $error);
         self::assertEquals(404, $error->status());
         self::assertEquals('Resource type "Test" not found', $error->title());
     }
@@ -81,7 +87,8 @@ class ExceptionTest extends TestCase
         self::assertInstanceOf(\Exception::class, $exception);
         self::assertEquals(403, $exception->getHttpStatus());
 
-        $error = $exception->createError();
+        $error = $exception->errors()->first();
+        self::assertInstanceOf(ErrorInterface::class, $error);
         self::assertEquals(403, $error->status());
         self::assertEquals('Test', $error->title());
     }
@@ -92,7 +99,8 @@ class ExceptionTest extends TestCase
         self::assertInstanceOf(\Exception::class, $exception);
         self::assertEquals(503, $exception->getHttpStatus());
 
-        $error = $exception->createError();
+        $error = $exception->errors()->first();
+        self::assertInstanceOf(ErrorInterface::class, $error);
         self::assertEquals(503, $error->status());
         self::assertEquals('Test', $error->title());
     }


### PR DESCRIPTION
Resolves the issue #22.