### PR TITLE
chore: support PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=7.2",
-    "psr/http-message": "^1.0"
+    "psr/http-message": "^1.0 || ^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -20,7 +20,7 @@ class HttpException extends JsonApiException
      * @param int $code
      * @param \Throwable|null $previous
      */
-    public function __construct(int $statusCode, string $message = '', $code = 0, \Throwable $previous = null)
+    public function __construct(int $statusCode, string $message = '', $code = 0, ?\Throwable $previous = null)
     {
         $this->statusCode = $statusCode;
         parent::__construct($message, $code, $previous);

--- a/src/JsonApiTrait.php
+++ b/src/JsonApiTrait.php
@@ -29,7 +29,7 @@ trait JsonApiTrait
      * @param ResourceInterface|null $resource
      * @return DocumentInterface
      */
-    protected function singleResourceDocument(ResourceInterface $resource = null): DocumentInterface
+    protected function singleResourceDocument(?ResourceInterface $resource = null): DocumentInterface
     {
         return new Document($resource);
     }
@@ -48,7 +48,7 @@ trait JsonApiTrait
      * @param ResourceInterface|null $related
      * @return RelationshipInterface
      */
-    protected function toOneRelationship(string $name, ResourceInterface $related = null): RelationshipInterface
+    protected function toOneRelationship(string $name, ?ResourceInterface $related = null): RelationshipInterface
     {
         return new Relationship($name, $related);
     }

--- a/src/Model/Request/Request.php
+++ b/src/Model/Request/Request.php
@@ -466,7 +466,7 @@ class Request implements RequestInterface
      * @param string|null $explodeBy
      * @return array|string|int|float
      */
-    public function filterValue(string $name, string $explodeBy = null)
+    public function filterValue(string $name, ?string $explodeBy = null)
     {
         if ($explodeBy) {
             return explode($explodeBy, $this->filter[$name]);

--- a/src/Model/Request/RequestInterface.php
+++ b/src/Model/Request/RequestInterface.php
@@ -117,7 +117,7 @@ interface RequestInterface
      * @param string|null $explodeBy
      * @return array|string|int|float
      */
-    public function filterValue(string $name, string $explodeBy = null);
+    public function filterValue(string $name, ?string $explodeBy = null);
 
     /**
      * Define a sort parameter. This method will manipulate the uri of the request.

--- a/src/Model/Resource/JsonResource.php
+++ b/src/Model/Resource/JsonResource.php
@@ -127,7 +127,7 @@ class JsonResource implements ResourceInterface, RelatedMetaInformationInterface
      * @return ResourceInterface
      * @throws \InvalidArgumentException
      */
-    public function duplicate(string $id = null): ResourceInterface
+    public function duplicate(?string $id = null): ResourceInterface
     {
         $resource = new self($this->type(), $id ?? $this->id(), $this->attributes()->all());
 

--- a/src/Model/Resource/Link/Link.php
+++ b/src/Model/Resource/Link/Link.php
@@ -77,7 +77,7 @@ class Link implements LinkInterface
      * @return LinkInterface
      * @throws \InvalidArgumentException
      */
-    public function duplicate(string $name = null): LinkInterface
+    public function duplicate(?string $name = null): LinkInterface
     {
         $link = new self($name ?? $this->name(), $this->href());
         $link->metaInformation()->mergeCollection($this->metaInformation());

--- a/src/Model/Resource/Link/LinkInterface.php
+++ b/src/Model/Resource/Link/LinkInterface.php
@@ -32,5 +32,5 @@ interface LinkInterface
      * @param string|null $name
      * @return LinkInterface
      */
-    public function duplicate(string $name = null): LinkInterface;
+    public function duplicate(?string $name = null): LinkInterface;
 }

--- a/src/Model/Resource/Relationship/Relationship.php
+++ b/src/Model/Resource/Relationship/Relationship.php
@@ -115,7 +115,7 @@ class Relationship implements RelationshipInterface
      * @return RelationshipInterface
      * @throws \InvalidArgumentException
      */
-    public function duplicate(string $name = null): RelationshipInterface
+    public function duplicate(?string $name = null): RelationshipInterface
     {
         if ($this->shouldBeHandledAsCollection()) {
             $related = [];

--- a/src/Model/Resource/Relationship/RelationshipInterface.php
+++ b/src/Model/Resource/Relationship/RelationshipInterface.php
@@ -46,5 +46,5 @@ interface RelationshipInterface
      * @param string|null $name
      * @return RelationshipInterface
      */
-    public function duplicate(string $name = null): RelationshipInterface;
+    public function duplicate(?string $name = null): RelationshipInterface;
 }

--- a/src/Model/Resource/ResourceCollection.php
+++ b/src/Model/Resource/ResourceCollection.php
@@ -64,7 +64,7 @@ class ResourceCollection extends AbstractCollection implements ResourceCollectio
      * @return ResourceInterface
      * @throws \LogicException
      */
-    public function first(string $type = null): ResourceInterface
+    public function first(?string $type = null): ResourceInterface
     {
         if ($this->isEmpty()) {
             throw new \LogicException('Collection does not contain any resources!');

--- a/src/Model/Resource/ResourceCollectionInterface.php
+++ b/src/Model/Resource/ResourceCollectionInterface.php
@@ -35,7 +35,7 @@ interface ResourceCollectionInterface extends CollectionInterface
      * @param string $type
      * @return ResourceInterface
      */
-    public function first(string $type = null): ResourceInterface;
+    public function first(?string $type = null): ResourceInterface;
 
     /**
      * @param ResourceInterface $resource

--- a/src/Model/Resource/ResourceInterface.php
+++ b/src/Model/Resource/ResourceInterface.php
@@ -49,5 +49,5 @@ interface ResourceInterface
      * @param string $id
      * @return ResourceInterface
      */
-    public function duplicate(string $id = null): ResourceInterface;
+    public function duplicate(?string $id = null): ResourceInterface;
 }


### PR DESCRIPTION
Fixes:
- `Implicitly marking parameter $var as nullable is deprecated, the explicit nullable type must be used instead`
- Allow `psr/htt-message^2.0`